### PR TITLE
EnumPriceTypeCode added and used for priceType

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -12,7 +12,7 @@ const fromPath = "src/";
 let typeIndex = {
     name: "Schema4i.org",
     description: "Schema for insurances (S4i)",
-    release: 0.85,
+    release: 0.86,
     modified: new Date(),
     objects: 0,
     enumerations: 0,

--- a/src/EnumPriceTypeCode.src.json
+++ b/src/EnumPriceTypeCode.src.json
@@ -1,0 +1,48 @@
+{
+  "type": "EnumPriceTypeCode",
+  "uri": "http://schema4i.org/EnumPriceTypeCode",
+  "description": "Code for coding the contribution types according to BiPRO.",
+  "links": [
+    {
+      "url": "http://schema4i.org/EnumPriceTypeCode_DE",
+      "description": "Original German documentation"
+    }
+  ],
+  "parents": [],
+  "base": [],
+  "multipletypes": {},
+  "context": {
+    "@context": {
+      "@version": 1.1,
+      "s4i": "http://schema4i.org/",
+      "Contribution including tax according to class tax": "s4i:EnumPriceTypeCode#01",
+      "Net contribution including any installment charge surcharge": "s4i:EnumPriceTypeCode#02",
+      "Tariff contribution without legal supplement acc. Variable (PKV)": "s4i:EnumPriceTypeCode#03",
+      "For unit-linked insurance contributions in accordance with. Paymentary, which is paid in investment funds (savings share)": "s4i:EnumPriceTypeCode#04",
+      "For fund-linked insurance contributions, which is paid into the investment funds (during the total contribution duration) in the investment funds (savings share total)": "s4i:EnumPriceTypeCode#05",
+      "Tariff contribution, total contribution gross without surplus charging (LV)": "s4i:EnumPriceTypeCode#06",
+      "Tariff contribution - annual fee including insurance tax, without deduction of discounts (conditions)": "s4i:EnumPriceTypeCode#08",
+      "Tariff contribution 100 (annual fee without consideration of all inflows and deductions, installment charge surcharge, fee and verse tax) (car)": "s4i:EnumPriceTypeCode#09",
+      "Base contribution, contribution without a premium factor - the original contribution to the base year (eg value 1914 in Mark at Building) (composite) (composite)": "s4i:EnumPriceTypeCode#10",
+      "Tax deductible setpoint in the PKV (acc. Bilder Relief Act)": "s4i:EnumPriceTypeCode#11",
+      "Sparrate (Rate, which is regularly paid in an investment.)": "s4i:EnumPriceTypeCode#12",
+      "fee": "s4i:EnumPriceTypeCode#13",
+      "100 participation (debt collection)": "s4i:EnumPriceTypeCode#14",
+      "Billing amount (Incasso billing)": "s4i:EnumPriceTypeCode#15",
+      "Basic contribution by calculation unit": "s4i:EnumPriceTypeCode#16",
+      "Basic contribution according to the calculation unit including collective agreements": "s4i:EnumPriceTypeCode#17",
+      "Basic contribution according to the calculation unit including all supplies": "s4i:EnumPriceTypeCode#18",
+      "Minimum contribution": "s4i:EnumPriceTypeCode#19",
+      "Varification contribution - the contribution to be paid in accordance with the minimum contributions (liability)": "s4i:EnumPriceTypeCode#20",
+      "Reduced initial contribution Total gross without surplus credit (analogical tariff post 07) as an amount (amount and health must be specified). In addition, the period of review must be specified.": "s4i:EnumPriceTypeCode#21",
+      "Reduced initial contribution Total gross without surplus charging (analogical tariff post 07) as a percentage (percentage must be specified if amount must not be specified). In addition, the period of review must be specified. A contribution to Artid07 must be specified as a reference by the same product block.": "s4i:EnumPriceTypeCode#22",
+      "Subsidy": "s4i:EnumPriceTypeCode#23",
+      "Payment": "s4i:EnumPriceTypeCode#24",
+      "Maximum contribution (in the case of Riester this is less the allowances)": "s4i:EnumPriceTypeCode#25",
+      "Residue charge": "s4i:EnumPriceTypeCode#26",
+      "Premium refund": "s4i:EnumPriceTypeCode#27",
+      "Contribution relief KV": "s4i:EnumPriceTypeCode#28",
+      "Net contribution Exclusive any installment charge surcharge": "s4i:EnumPriceTypeCode#29"
+    }
+  }
+}

--- a/src/EnumPriceTypeCode_DE.src.json
+++ b/src/EnumPriceTypeCode_DE.src.json
@@ -1,0 +1,48 @@
+{
+  "type": "EnumPriceTypeCode_DE",
+  "uri": "http://schema4i.org/EnumPriceTypeCode_DE",
+  "description": "Code für die Schlüsselung der Beitragsarten nach BiPRO.",
+  "links": [
+    {
+      "url": "http://schema4i.org/EnumPriceTypeCode",
+      "description": "Englische Dokumentation der Schlüsselwerte"
+    }
+  ],
+  "parents": [],
+  "base": [],
+  "multipletypes": {},
+  "context": {
+    "@context": {
+      "@version": 1.1,
+      "s4i": "http://schema4i.org/",
+      "Beitrag inkl. Steuer gemäß Klasse Steuer": "s4i:EnumPriceTypeCode#01",
+      "Nettobeitrag inklusive etwaigem Ratenzahlungszuschlag": "s4i:EnumPriceTypeCode#02",
+      "Tarifbeitrag ohne gesetzlichen Zuschlag gem. Zahlweise (PKV)": "s4i:EnumPriceTypeCode#03",
+      "Bei fondsgebundenen Versicherungen der Beitragsanteil gem. Zahlweise, der in Investmentfonds eingezahlt wird (Sparanteil)": "s4i:EnumPriceTypeCode#04",
+      "Bei fondsgebundenen Versicherungen der Beitragsanteil, der insgesamt (während der gesamten Beitragszahldauer) in die Investmentfonds eingezahlt wird (Sparanteil gesamt)": "s4i:EnumPriceTypeCode#05",
+      "Tarifbeitrag, Gesamtbeitrag Brutto ohne Überschussverrechnung (LV)": "s4i:EnumPriceTypeCode#06",
+      "Tarifbeitrag - Jahresbeitrag inklusive Versicherungssteuer, ohne Abzug von Rabatten (Konditionen)": "s4i:EnumPriceTypeCode#08",
+      "Tarifbeitrag 100 (Jahresbeitrag ohne Berücksichtigung aller Zu- und Abschläge, Ratenzahlungszuschlag, Gebühr und Vers.-Steuer ) (KFZ)": "s4i:EnumPriceTypeCode#09",
+      "Basisbeitrag, Beitrag ohne Prämienfaktor - Der Ursprungsbeitrag zum Basisjahr (z. B. Wert 1914 in Mark bei Gebäude)(Komposit)(Komposit)": "s4i:EnumPriceTypeCode#10",
+      "Steuerlich abzugsfähiger Sollbeitrag in der PKV (gem. Bürgerentlastungsgesetz)": "s4i:EnumPriceTypeCode#11",
+      "Sparrate (Rate, die regelmäßig in eine Kapitalanlage eingezahlt wird.)": "s4i:EnumPriceTypeCode#12",
+      "Gebühr": "s4i:EnumPriceTypeCode#13",
+      "100 Beteiligung (Inkasso Abrechnung)": "s4i:EnumPriceTypeCode#14",
+      "Abrechnungsbetrag (Inkasso Abrechnung)": "s4i:EnumPriceTypeCode#15",
+      "Grundbeitrag nach Berechnungseinheit": "s4i:EnumPriceTypeCode#16",
+      "Grundbeitrag nach Berechnungseinheit inklusive tarifliche Zu- Abschläge": "s4i:EnumPriceTypeCode#17",
+      "Grundbeitrag nach Berechnungseinheit inklusive aller Zu- Abschläge": "s4i:EnumPriceTypeCode#18",
+      "Mindestbeitrag": "s4i:EnumPriceTypeCode#19",
+      "Wagnisbeitrag - Der zu zahlende Beitrag unter Beachtung der Mindestbeiträge (Haftpflicht)": "s4i:EnumPriceTypeCode#20",
+      "Verminderter Anfangsbeitrag gesamt brutto ohne Überschussverrechnung (analog Tarifbeitrag 07) als Betrag (Betrag und Waehrung MÜSSEN angegeben werden). Zusätzlich MUSS der Zeitraum Beitrag.Erhebung angegeben werden.": "s4i:EnumPriceTypeCode#21",
+      "Verminderter Anfangsbeitrag gesamt brutto ohne Überschussverrechnung (analog Tarifbeitrag 07) als Prozentsatz (Prozentsatz MUSS angegeben werden Betrag DARF NICHT angegeben werden). Zusätzlich MUSS der Zeitraum Beitrag.Erhebung angegeben werden. Es MUSS ein Beitrag mit ArtID07 als Bezugsgröße am selben Produktbaustein angegeben werden.": "s4i:EnumPriceTypeCode#22",
+      "Förderbeitrag": "s4i:EnumPriceTypeCode#23",
+      "Zuzahlung": "s4i:EnumPriceTypeCode#24",
+      "Maximalbeitrag (Im Falle von Riester ist dieser abzüglich der Zulagen)": "s4i:EnumPriceTypeCode#25",
+      "Rückstandsverrechnung": "s4i:EnumPriceTypeCode#26",
+      "Prämienrückerstattung": "s4i:EnumPriceTypeCode#27",
+      "Beitragsentlastung KV": "s4i:EnumPriceTypeCode#28",
+      "Nettobeitrag exklusive etwaigem Ratenzahlungszuschlag": "s4i:EnumPriceTypeCode#29"
+    }
+  }
+}

--- a/src/FinancialProduct.src.json
+++ b/src/FinancialProduct.src.json
@@ -105,5 +105,50 @@
             }
         },
         "context": {}
+    },{
+        "title": "A FinancialProduct with different price components (Insurance)",
+        "tab": "tab-expanded",
+        "input": {
+            "@context": [
+                "http://schema4i.org/FinancialProduct.jsonld",
+                "http://schema4i.org/Service.jsonld",
+                "http://schema4i.org/CompoundPriceSpecification.jsonld",
+                "http://schema4i.org/UnitPriceSpecification.jsonld",
+                "http://schema4i.org/PriceSpecification.jsonld",
+                "http://schema4i.org/Organization.jsonld",
+                "http://schema4i.org/Thing.jsonld"
+            ],
+            "@type": "FinancialProduct",
+            "Category": "RENTE",
+            "Description": "IDEAL UniversalLife - Hohe Sicherheit bei 3,3% Verzinsung",
+            "Identifier": "1047.IUL.Selbststaendige",
+            "Logo": "https://www.ideal-versicherung.de/templates/masterbootstrap/images/elements/IDEAL-Logo.svg",
+            "Name": "Rente für Selbstständige",
+            "Provider": {
+                "@type": "Organization",
+                "Identifier": "1047",
+                "Name": "IDEAL"
+            },
+            "PaymentInterval": 7,
+            "Price": 153.21,
+            "PriceCurrency": "EUR",
+            "PriceSpecification": {
+                "@type": "CompoundPriceSpecification",
+                "PriceComponent": [{
+                    "@type": "UnitPriceSpecification",
+                    "PriceType": "01",
+                    "Price": 153.21,
+                    "PriceCurrency": "EUR",
+                    "Identifier": "16111274782378904"
+                }, {
+                    "@type": "UnitPriceSpecification",
+                    "PriceType": "02",
+                    "Price": 113.21,
+                    "PriceCurrency": "EUR",
+                    "Identifier": "16111274282323409"
+                }]
+            }
+        },
+        "context": {}
     }]
 }

--- a/src/UnitPriceSpecification.src.json
+++ b/src/UnitPriceSpecification.src.json
@@ -12,7 +12,12 @@
     "base": [
         { "@id": "http://schema4i.org/PriceSpecification" }
     ],
-    "multipletypes": {},
+    "multipletypes": {
+        "PriceType": [
+            { "@id": "http://schema.org/Text" },
+            { "@id": "http://schema4i.org/EnumPriceTypeCode" }
+        ]
+    },
     "context": {
         "@context": {
             "@version": 1.1,
@@ -20,8 +25,7 @@
             "schema": "http://schema.org/",
             "UnitPriceSpecification": "schema:UnitPriceSpecification",
             "PriceType": {
-                "@id": "schema:priceType",
-                "@type": "schema:Text"
+                "@id": "schema:priceType"
             },
             "ReferenceQuantity": {
                 "@id": "schema:referenceQuantity",


### PR DESCRIPTION
EnumPriceTypeCode was added and used for priceType. Also added an example for FinancialProduct which uses priceType.