### PR TITLE
skip generation typeof methods for Property and Enumeration

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -43,6 +43,11 @@ const PRIMITIVE_TYPE_MAPPINGS = {
     '@vocab': 'string' // enums not in the s4i schema
 }
 
+const SKIP_TYPEOF_CHECKER = [
+    'Property',
+    'Enumeration'
+]
+
 /**
  * @param {string} type
  * @param {any} typeObject
@@ -307,10 +312,12 @@ function isType(obj: any, type: string) {
 `;
             for (const typeDefinition of typeDefinitions) {
                 if (!typeDefinition.simpleType) {
-                    const childTypes = typeDefinitions.filter(td => td.baseTypes.includes(typeDefinition.type));
+                    const childTypes = typeDefinitions.filter(td => td.baseTypes.includes(typeDefinition.type) && !SKIP_TYPEOF_CHECKER.includes(td.type));
                     const ancestors = typeDefinition.listAncestors(typeDefinitions);
                     const descendants = typeDefinition.listDescendants(typeDefinitions);
-                    output += `
+
+                    if (!SKIP_TYPEOF_CHECKER.includes(typeDefinition.type)) {
+                        output += `
 /**
  * Checks if the given object is an instance of ${typeDefinition.type}.
  */
@@ -319,6 +326,7 @@ export function is${typeDefinition.type}(obj: any): obj is s4i.${typeDefinition.
 }
 
 `;
+                    }
 
                     if (ancestors.length > 0) {
 

--- a/src/AnswerSpecification.src.json
+++ b/src/AnswerSpecification.src.json
@@ -6,7 +6,9 @@
     "parents": [{
         "@id": "http://schema4i.org/Question#AnswerSpecification"
     }],
-    "base": [],
+    "base": [
+        { "@id": "http://schema4i.org/Property" }
+    ],
     "multipletypes": {},
     "context": {
         "@context": {

--- a/src/Basement.src.json
+++ b/src/Basement.src.json
@@ -9,7 +9,9 @@
     "parents": [
         { "@id": "http://schema4i.org/Place#ContainsPlace" }
     ],
-    "base": [],
+    "base": [
+        { "@id": "http://schema4i.org/Place" }
+    ],
     "multipletypes": {},
     "context": {
         "@context": {

--- a/src/Breed.src.json
+++ b/src/Breed.src.json
@@ -7,7 +7,9 @@
         { "@id": "http://schema4i.org/Animal#Breed" },
         { "@id": "http://schema4i.org/Dog#Breed" }
     ],
-    "base": [],
+    "base": [
+        { "@id": "http://schema4i.org/Property" }
+    ],
     "multipletypes": {
         "Breed": [
             { "@id": "http://schema.org/Text" },

--- a/src/Content.src.json
+++ b/src/Content.src.json
@@ -6,7 +6,9 @@
     "parents": [{
         "@id": "http://schema4i.org/Answer#Content"
     }],
-    "base": [],
+    "base": [
+        { "@id": "http://schema4i.org/Property" }
+    ],
     "multipletypes": {},
     "context": {
         "@context": {

--- a/src/NationalBankCode.src.json
+++ b/src/NationalBankCode.src.json
@@ -6,7 +6,9 @@
     "parents": [{
         "@id": "http://schema4i.org/BankOrCreditUnion#NationalBankCode"
     }],
-    "base": [],
+    "base": [
+        { "@id": "http://schema4i.org/Property" }
+    ],
     "multipletypes": {},
     "context": {
         "@context": {

--- a/src/OrderModificationCode.src.json
+++ b/src/OrderModificationCode.src.json
@@ -12,7 +12,9 @@
     "parents": [{
         "@id": "http://schema4i.org/Order#ModificationCode"
     }],
-    "base": [],
+    "base": [
+        { "@id": "http://schema4i.org/Property" }
+    ],
     "multipletypes": {},
     "context": {
         "@context": {

--- a/src/Owner.src.json
+++ b/src/Owner.src.json
@@ -6,7 +6,9 @@
     "parents": [
         { "@id": "http://schema4i.org/Vehicle#Owner" }
     ],
-    "base": [],
+    "base": [
+        { "@id": "http://schema4i.org/Property" }
+    ],
     "multipletypes": {
         "Owner": [
             { "@id": "http://schema4i.org/Person" },

--- a/src/ValueType.src.json
+++ b/src/ValueType.src.json
@@ -16,7 +16,7 @@
             "s4i": "http://schema4i.org/",
             "schema": "http://schema.org/",
             "ValueType": {
-                "@id": "s4i:Copy",
+                "@id": "s4i:ValueType",
                 "@type": "schema:URL"
             }
         }

--- a/src/ValueType.src.json
+++ b/src/ValueType.src.json
@@ -6,7 +6,9 @@
     "parents": [
         { "@id": "http://schema4i.org/PropertyValueSpecification#ValueType" }
     ],
-    "base": [],
+    "base": [
+        { "@id": "http://schema4i.org/Property" }
+    ],
     "multipletypes": {},
     "context": {
         "@context": {


### PR DESCRIPTION
Creating these methods would require typeof methods for all Properties and Enums. There is little use for that, since those types are only ever used in abstract descriptions of the schema within the schema itself. Additionally, these types could never be used as union types, since a Property cannot reasonably be two different Properties at once.