### PR TITLE
corrected Enum for EnumTypeOfVehicleUseCode

### DIFF
--- a/src/EnumTypeOfVehicleUseCode.src.json
+++ b/src/EnumTypeOfVehicleUseCode.src.json
@@ -21,12 +21,12 @@
             "@version": 1.1,
             "s4i": "http://schema4i.org/",
             "Mostly for business": "s4i:EnumTypeOfVehicleUseCode#01",
-            "Only private": "s4i:EnumTypeOfVehicleUseCode#02",
+            "Mostly private": "s4i:EnumTypeOfVehicleUseCode#02",
             "Taxi": "s4i:EnumTypeOfVehicleUseCode#03",
             "Rental": "s4i:EnumTypeOfVehicleUseCode#04",
             "Others": "s4i:EnumTypeOfVehicleUseCode#05",
             "Exclusively for business": "s4i:EnumTypeOfVehicleUseCode#06",
-            "Mostly private": "s4i:EnumTypeOfVehicleUseCode#07",
+            "Only private": "s4i:EnumTypeOfVehicleUseCode#07",
             "Private and business": "s4i:EnumTypeOfVehicleUseCode#08",
             "Agriculture": "s4i:EnumTypeOfVehicleUseCode#09"
         }

--- a/src/EnumTypeOfVehicleUseCode_DE.src.json
+++ b/src/EnumTypeOfVehicleUseCode_DE.src.json
@@ -21,12 +21,12 @@
             "@version": 1.1,
             "s4i": "http://schema4i.org/",
             "Überwiegend geschäftlich": "s4i:EnumTypeOfVehicleUseCode#01",
-            "Ausschließlich Privat": "s4i:EnumTypeOfVehicleUseCode#02",
+            "Überwiegend Privat": "s4i:EnumTypeOfVehicleUseCode#02",
             "Taxi": "s4i:EnumTypeOfVehicleUseCode#03",
             "Vermietung": "s4i:EnumTypeOfVehicleUseCode#04",
             "Sonstige": "s4i:EnumTypeOfVehicleUseCode#05",
             "Ausschließlich geschäftlich": "s4i:EnumTypeOfVehicleUseCode#06",
-            "Überwiegend Privat": "s4i:EnumTypeOfVehicleUseCode#07",
+            "Ausschließlich Privat": "s4i:EnumTypeOfVehicleUseCode#07",
             "Privat und geschäftlich": "s4i:EnumTypeOfVehicleUseCode#08",
             "Landwirtschaft": "s4i:EnumTypeOfVehicleUseCode#09"
         }


### PR DESCRIPTION
The values of 02 and 07 in schema4i  were swapped according to Bipro 2.7 ST_Nutzungsart : Public Enumeration. This merge Request corrects it according to Bipro spec