### PR TITLE
Added Context for UnitCode to all legacy QuantitativeValues with Unit…

### DIFF
--- a/src/Accommodation.src.json
+++ b/src/Accommodation.src.json
@@ -118,12 +118,24 @@
             "FloorPlan": {
                 "@type": "FloorPlan",
                 "NumberOfAccommodationUnits": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "UnitCode": "H87",
                     "Value": 4
                 }
             },
             "FloorSize": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "Name": "Size",
                 "Value": 1457,

--- a/src/BusinessActivity.src.json
+++ b/src/BusinessActivity.src.json
@@ -63,6 +63,12 @@
                 },
                 "TermCode": "4711",
                 "YearlyRevenue": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": 100000,
                     "UnitCode": "M4",

--- a/src/CareIncomeCoverage.src.json
+++ b/src/CareIncomeCoverage.src.json
@@ -50,6 +50,12 @@
                 ],
                 "@type": "Dividend",
                 "Amount": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": "100",
                     "UnitCode": "P1"

--- a/src/Coverage.src.json
+++ b/src/Coverage.src.json
@@ -134,6 +134,12 @@
                 "Value": 1000,
                 "Currency": "EUR"
             },{
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "Value": 2,
                 "UnitCode": "P1"
@@ -161,6 +167,12 @@
                     }
                 },
                 "Value": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "UnitCode": "P1",
                     "Value": "25"

--- a/src/DeathCoverage.src.json
+++ b/src/DeathCoverage.src.json
@@ -51,6 +51,12 @@
                 ],
                 "@type": "Dividend",
                 "Amount": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": "100",
                     "UnitCode": "P1"

--- a/src/DisabilityCoverage.src.json
+++ b/src/DisabilityCoverage.src.json
@@ -51,6 +51,12 @@
                 ],
                 "@type": "Dividend",
                 "Amount": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": "100",
                     "UnitCode": "P1"

--- a/src/Dividend.src.json
+++ b/src/Dividend.src.json
@@ -43,6 +43,12 @@
             ],
             "@type": "Dividend",
             "Amount": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "Value": "100",
                 "UnitCode": "P1"
@@ -68,6 +74,12 @@
             ],
             "@type": "Dividend",
             "Amount": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "Value": "100",
                 "UnitCode": "P1"
@@ -94,6 +106,12 @@
             ],
             "@type": "Dividend",
             "Amount": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "Value": "100",
                 "UnitCode": "P1"

--- a/src/DividendUsage.src.json
+++ b/src/DividendUsage.src.json
@@ -39,6 +39,12 @@
             "DividendUsage": {
                 "@type": "Dividend",
                 "Amount": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": "100",
                     "UnitCode": "P1"

--- a/src/Filter.src.json
+++ b/src/Filter.src.json
@@ -203,6 +203,12 @@
                     }
                 },
                 "FilterItemMinThreshold": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": "2",
                     "UnitCode": "P1"
@@ -235,6 +241,12 @@
                     }
                 },
                 "FilterItemMinThreshold": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": "30",
                     "UnitCode": "C62"

--- a/src/FilterItemMinThreshold.src.json
+++ b/src/FilterItemMinThreshold.src.json
@@ -41,6 +41,12 @@
                         "Keywords": "Dokument"
                     }
                 }, {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": "2",
                     "UnitCode": "P1"
@@ -68,6 +74,12 @@
                         "Keywords": "Dokument"
                     }
                 }, {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": "30",
                     "UnitCode": "C62"

--- a/src/FloorPlan.src.json
+++ b/src/FloorPlan.src.json
@@ -33,6 +33,12 @@
             ],
             "@type": "FloorPlan",
             "NumberOfAccommodationUnits": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "UnitCode": "H87",
                 "Value": 4

--- a/src/FuelTank.src.json
+++ b/src/FuelTank.src.json
@@ -29,6 +29,12 @@
             ],
             "@type": "FuelTank",
             "FuelCapacity": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "Name": "Capacity",
                 "Value": 320,

--- a/src/HealthCoverage.src.json
+++ b/src/HealthCoverage.src.json
@@ -67,6 +67,12 @@
                 "@type": "InsuranceBenefit",
                 "BenefitType": "LeistungAbTag",
                 "Value": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": 43,
                     "UnitCode": "D"

--- a/src/InsuranceProduct.src.json
+++ b/src/InsuranceProduct.src.json
@@ -151,6 +151,12 @@
                 "Value": 150,
                 "Currency": "EUR"
             },{
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "Value": 2,
                 "UnitCode": "P1"

--- a/src/OfferForPurchase.src.json
+++ b/src/OfferForPurchase.src.json
@@ -43,6 +43,12 @@
                 "FloorLevel": 1,
                 "AmenityFeature": [],
                 "FloorSize": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Name": "Size",
                     "Value": 1457,

--- a/src/Organization.src.json
+++ b/src/Organization.src.json
@@ -200,6 +200,12 @@
             "Logo": "https://www.b-tix.de/wp-content/uploads/2015/04/b-tix_logo_weiss_textlos_klein.png",
             "Telephone": "0049 211 41608 400",
             "YearlyRevenue": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "Value": {
                     "@type": "MonetaryAmount",

--- a/src/Person.src.json
+++ b/src/Person.src.json
@@ -255,6 +255,12 @@
                         "@type": "InsuranceBenefit",
                         "BenefitType": "AmbulanteVollversicherung",
                         "Value": {
+                            "@context": {
+                                "UnitCode": {
+                                    "@id": "http://schema.org/unitCode",
+                                    "@type": "http://schema.org/Text"
+                                }
+                            },
                             "@type": "QuantitativeValue",
                             "Value": 50,
                             "UnitCode": "P1"
@@ -289,6 +295,12 @@
                         "@type": "InsuranceBenefit",
                         "BenefitType": "StationaereVollversicherung",
                         "Value": {
+                            "@context": {
+                                "UnitCode": {
+                                    "@id": "http://schema.org/unitCode",
+                                    "@type": "http://schema.org/Text"
+                                }
+                            },
                             "@type": "QuantitativeValue",
                             "Value": 50,
                             "UnitCode": "P1"
@@ -323,6 +335,12 @@
                         "@type": "InsuranceBenefit",
                         "BenefitType": "ZahnVollversicherung",
                         "Value": {
+                            "@context": {
+                                "UnitCode": {
+                                    "@id": "http://schema.org/unitCode",
+                                    "@type": "http://schema.org/Text"
+                                }
+                            },
                             "@type": "QuantitativeValue",
                             "Value": 100,
                             "UnitCode": "P1"

--- a/src/Place.src.json
+++ b/src/Place.src.json
@@ -194,6 +194,12 @@
                 "Salutation": "3"
             },
             "Altitude": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "UnitCode": "MTR",
                 "Value": 2

--- a/src/QuantitativeValue.src.json
+++ b/src/QuantitativeValue.src.json
@@ -66,7 +66,15 @@
         "input": {
             "@context": [
                 "http://schema4i.org/Thing.jsonld",
-                "http://schema4i.org/QuantitativeValue.jsonld"
+                "http://schema4i.org/QuantitativeValue.jsonld",
+                {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    }
+                }
             ],
             "@type": "QuantitativeValue",
             "AdditionalProperty": {},

--- a/src/RealEstateListing.src.json
+++ b/src/RealEstateListing.src.json
@@ -62,6 +62,12 @@
                     "FloorLevel": 1,
                     "AmenityFeature": [],
                     "FloorSize": {
+                        "@context": {
+                            "UnitCode": {
+                                "@id": "http://schema.org/unitCode",
+                                "@type": "http://schema.org/Text"
+                            }
+                        },
                         "@type": "QuantitativeValue",
                         "Name": "Size",
                         "Value": 1457,

--- a/src/RetirementIncomeCoverage.src.json
+++ b/src/RetirementIncomeCoverage.src.json
@@ -71,6 +71,12 @@
                 ],
                 "@type": "Dividend",
                 "Amount": {
+                    "@context": {
+                        "UnitCode": {
+                            "@id": "http://schema.org/unitCode",
+                            "@type": "http://schema.org/Text"
+                        }
+                    },
                     "@type": "QuantitativeValue",
                     "Value": "100",
                     "UnitCode": "P1"

--- a/src/Share.src.json
+++ b/src/Share.src.json
@@ -36,6 +36,12 @@
             ],
             "@type": "Share",
             "Value": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "UnitCode": "P1",
                 "Value": "25"

--- a/src/Uses.src.json
+++ b/src/Uses.src.json
@@ -78,6 +78,12 @@
                             "@type": "InsuranceBenefit",
                             "BenefitType": "AmbulanteVollversicherung",
                             "Value": {
+                                "@context": {
+                                    "UnitCode": {
+                                        "@id": "http://schema.org/unitCode",
+                                        "@type": "http://schema.org/Text"
+                                    }
+                                },
                                 "@type": "QuantitativeValue",
                                 "Value": 50,
                                 "UnitCode": "P1"
@@ -112,6 +118,12 @@
                             "@type": "InsuranceBenefit",
                             "BenefitType": "StationaereVollversicherung",
                             "Value": {
+                                "@context": {
+                                    "UnitCode": {
+                                        "@id": "http://schema.org/unitCode",
+                                        "@type": "http://schema.org/Text"
+                                    }
+                                },
                                 "@type": "QuantitativeValue",
                                 "Value": 50,
                                 "UnitCode": "P1"
@@ -146,6 +158,12 @@
                             "@type": "InsuranceBenefit",
                             "BenefitType": "ZahnVollversicherung",
                             "Value": {
+                                "@context": {
+                                    "UnitCode": {
+                                        "@id": "http://schema.org/unitCode",
+                                        "@type": "http://schema.org/Text"
+                                    }
+                                },
                                 "@type": "QuantitativeValue",
                                 "Value": 100,
                                 "UnitCode": "P1"

--- a/src/Vehicle.src.json
+++ b/src/Vehicle.src.json
@@ -150,6 +150,12 @@
             "Manufacturer": {},
             "ManufacturerKeyNumber": "0583",
             "MileageFromOdometer": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
                 "@type": "QuantitativeValue",
                 "Value": "150524.92",
                 "UnitCode": "MTR"


### PR DESCRIPTION
Due to UnitCode now accepting schema:text or two newly added Enums, a context on all legacy usages is required to designate that they are of type text.