### PR TITLE
Typos and small fixes

### DIFF
--- a/src/BeneficialOwnership.src.json
+++ b/src/BeneficialOwnership.src.json
@@ -33,6 +33,10 @@
                 "@id": "s4i:AffectedBy",
                 "@type": "s4i:Thing"
             },
+            "Affects": {
+                "@id": "s4i:Affects",
+                "@type": "s4i:Thing"
+            },
             "BeneficialOwner": {
                 "@id": "s4i:BeneficialOwner"
             },
@@ -78,6 +82,7 @@
                     "CodingSystem": "ICD-10"
                 }
             }],
+            "Affects": [],
             "Irrevocable": false
         },
         "context": {}

--- a/src/EnumBusinessRelationshipCode.src.json
+++ b/src/EnumBusinessRelationshipCode.src.json
@@ -33,7 +33,7 @@
             "co-owner": "s4i:EnumBusinessRelationshipCode#36",
             "carrier": "s4i:EnumBusinessRelationshipCode#37",
             "department": "s4i:EnumBusinessRelationshipCode#38",
-            "representitive": "s4i:EnumBusinessRelationshipCode#48",
+            "representative": "s4i:EnumBusinessRelationshipCode#48",
             "member": "s4i:EnumBusinessRelationshipCode#49"
         }
     }

--- a/src/RoleCode.src.json
+++ b/src/RoleCode.src.json
@@ -12,7 +12,11 @@
     "multipletypes": {
         "RoleCode": [
             { "@id": "http://schema.org/Text" },
-            { "@id": "http://schema4i.org/EnumEventParticipantRoleCode" }
+            { "@id": "http://schema4i.org/EnumEventParticipantRoleCode" },
+            { "@id": "http://schema4i.org/EnumClaimPartnerRoleCode" },
+            { "@id": "http://schema4i.org/EnumOrderPartnerRoleCode" },
+            { "@id": "http://schema4i.org/EnumMoneyTransferRoleCode" },
+            { "@id": "http://schema4i.org/EnumVehicleDriverRoleCode" }
         ]
     },
     "context": {


### PR DESCRIPTION
Typos:
- RelationshipCode typo `representitive` -> `representative`

Fixes:
- RoleCode.src.json had multitypes of { "@id": "http://schema.org/Text" }, and { "@id": "http://schema4i.org/EnumEventParticipantRoleCode" } but in Role.src.json it can be one of  http://schema.org/Text | http://localhost:4201EnumEventParticipantRoleCode | http://localhost:4201/EnumClaimPartnerRoleCode | http://localhost:4201/EnumOrderPartnerRoleCode | http://localhost:4201/EnumMoneyTransferRoleCode | http://localhost:4201/EnumVehicleDriverRoleCode. so i added them as multitypes in RoleCode.src.json aswell
- Added Affects in BenefitialOwner. Affects is @type Thing