### PR TITLE
Adds RoleBearerID to BusinessRelationshipRole

### DIFF
--- a/src/BusinessRelationshipRole.src.json
+++ b/src/BusinessRelationshipRole.src.json
@@ -30,6 +30,10 @@
             },
             "BusinessRelationship": {
                 "@id": "s4i:BusinessRelationship"
+            },
+            "RoleBearerID": {
+                "@id": "s4i:RoleBearerID",
+                "@type": "s4i:ID"
             }
         }
     },


### PR DESCRIPTION
This commits adds RoleBearerID to BusinessRelationshipRole, RoleBearerID is of type ID and contains Partnernummer and PartnernummerVM depending on the value of EnumOrderPartnerRoleCode 