### PR TITLE
add geoarea to Place

### DIFF
--- a/src/GeoArea.src.json
+++ b/src/GeoArea.src.json
@@ -1,0 +1,39 @@
+{
+    "type": "GeoArea",
+    "uri": "http://schema4i.org/GeoArea",
+    "description": "Represents the geographic size or surface area of the property or land. The value is measured and expressed in either square meters or hectares ",
+    "links": [],
+    "parents":[{
+        "@id": "http://schema4i.org/Place#GeoArea"
+    }],
+    "base":[
+        { "@id": "http://schema4i.org/Property" }
+    ],
+    "multipletypes": {},
+    "context": {
+        "@context": {
+            "@version": 1.1,
+            "s4i": "http://schema4i.org/",
+            "GeoArea": {
+                "@id": "s4i:GeoArea",
+                "@type": "s4i:QuantitativeValue"
+            }
+        }
+    },
+    "playground":[{
+        "title": "A simple GeoArea in squaremeters",
+        "tab": "tab-expanded",
+        "input": {
+            "@context": {
+                "UnitCode": {
+                    "@id": "http://schema.org/unitCode",
+                    "@type": "http://schema.org/Text"
+                }
+            },
+            "@type": "QuantitativeValue",
+            "Value": 1457,
+            "UnitCode": "MTK",
+            "UnitText": "sqm"
+        }
+    }]
+}

--- a/src/Place.src.json
+++ b/src/Place.src.json
@@ -51,6 +51,10 @@
                 "@id": "schema:containsPlace",
                 "@type": "s4i:Place"
             },
+            "GeoArea": {
+                "@id": "s4i:GeoArea",
+                "@type": "s4i:QuantitativeValue"
+            },
             "GeoContains": {
                 "@id": "schema:geoContains",
                 "@type": "s4i:Place"
@@ -220,6 +224,18 @@
                         "Identifier": "4711"
                     }
                 }
+            },
+            "GeoArea": {
+                "@context": {
+                    "UnitCode": {
+                        "@id": "http://schema.org/unitCode",
+                        "@type": "http://schema.org/Text"
+                    }
+                },
+                "@type": "QuantitativeValue",
+                "Value": 1457,
+                "UnitCode": "MTK",
+                "UnitText": "sqm"
             }
         },
         "context": {}


### PR DESCRIPTION
This commit adds GeoArea to s4i.Place. This allows users to define the surface area of a plot of land in squaremeters or hectares