### PR TITLE
Change ModificationCode to MultipleType

### DIFF
--- a/src/EnumGDVModificationCode.src.json
+++ b/src/EnumGDVModificationCode.src.json
@@ -1,0 +1,63 @@
+{
+    "type": "EnumGDVModificationCode",
+    "uri": "http://schema4i.org/EnumGDVModificationCode",
+    "description": "Two-digit identification code for a business transaction in accordance with the GDV standard (2013 release). It is used, for example, to code the reason for a change to an insurance contract (Order#ModificationCode).",
+    "links": [{
+            "url": "http://schema4i.org/EnumGDVModificationCode_DE",
+            "description": "Orignal German Dokumentation"
+        }
+    ],
+    "parents": [
+        { "@id": "http://schema4i.org/Order#ModificationCode" }
+    ],
+    "base": [
+        { "@id": "http://schema4i.org/Enumeration" }
+    ],
+    "multipletypes": {},
+    "context": {
+        "@context": {
+            "@version": 1.1,
+            "s4i": "http://schema4i.org/",
+            "Initial setup (snapshot inventory, portfolio transfer)": "s4i:EnumTransactionCode#00",
+            "Initial delivery of a contract with new contract number after contract separation / supplementary insurance, e.g. conversion from individual insurance to group insurance / conversion from group insurance to individual insurance": "s4i:EnumTransactionCode#01",
+            "Policyholder change": "s4i:EnumTransactionCode#02",
+            "Vehicle change": "s4i:EnumTransactionCode#03",
+            "Change of regional class / tariff group / vehicle type class (motor insurance)": "s4i:EnumTransactionCode#04",
+            "Change of coverage scope / insurance protection / transition from full insurance to entitlement insurance or from entitlement insurance to full insurance": "s4i:EnumTransactionCode#05",
+            "Change of no-claims discount classification (motor insurance) / premium refund (health insurance)": "s4i:EnumTransactionCode#06",
+            "Short-term inclusion or change of coverage": "s4i:EnumTransactionCode#07",
+            "Reinstatement": "s4i:EnumTransactionCode#08",
+            "Change of insurance duration / insurance start date": "s4i:EnumTransactionCode#09",
+            "Change relating to risk / risk surcharge / exclusion of benefits": "s4i:EnumTransactionCode#10",
+            "Change of conditions": "s4i:EnumTransactionCode#11",
+            "Contractual increase in benefits / dynamic benefit adjustment": "s4i:EnumTransactionCode#12",
+            "Change of payment method / due date": "s4i:EnumTransactionCode#13",
+            "Change of sum insured": "s4i:EnumTransactionCode#14",
+            "Increase of supplementary insurance": "s4i:EnumTransactionCode#15",
+            "Inclusion of supplementary coverage": "s4i:EnumTransactionCode#16",
+            "Exclusion of supplementary coverage": "s4i:EnumTransactionCode#17",
+            "Change of premiums (e.g. premium adjustment, contractual premium increase)": "s4i:EnumTransactionCode#18",
+            "Change of personal data": "s4i:EnumTransactionCode#19",
+            "Contract consolidation": "s4i:EnumTransactionCode#20",
+            "Replacement contract": "s4i:EnumTransactionCode#21",
+            "Portfolio transfer (transfer from another intermediary)": "s4i:EnumTransactionCode#22",
+            "Agency number change (internal change of organizational unit at intermediary)": "s4i:EnumTransactionCode#23",
+            "New business after contract restructuring": "s4i:EnumTransactionCode#24",
+            "New business after tariff change": "s4i:EnumTransactionCode#25",
+            "Rejection of dynamic increase": "s4i:EnumTransactionCode#26",
+            "Contractual increase in benefits / non-dynamic benefit adjustment (e.g. for build-up models)": "s4i:EnumTransactionCode#27",
+            "Conversion of death benefit into percentage": "s4i:EnumTransactionCode#28",
+            "Removal of risk waiting period": "s4i:EnumTransactionCode#29",
+            "Tariff-based premium conversion (e.g. tariff with reduced initial premium)": "s4i:EnumTransactionCode#30",
+            "Tariff change (policy number remains unchanged)": "s4i:EnumTransactionCode#31",
+            "Additional payment": "s4i:EnumTransactionCode#32",
+            "Change of beneficiary rights": "s4i:EnumTransactionCode#33",
+            "Subsequent invoice": "s4i:EnumTransactionCode#34",
+            "Main due date invoice": "s4i:EnumTransactionCode#35",
+            "New business due to takeover from another insurer": "s4i:EnumTransactionCode#36",
+            "Transfer to another insurer": "s4i:EnumTransactionCode#37",
+            "No-claims discount change for dependent vehicles with interchangeable license plates (W-AKZ)": "s4i:EnumTransactionCode#38",
+            "Other change": "s4i:EnumTransactionCode#99"
+        }
+    }
+}

--- a/src/EnumGDVModificationCode_DE.src.json
+++ b/src/EnumGDVModificationCode_DE.src.json
@@ -1,0 +1,67 @@
+{
+    "type": "EnumGDVModificationCode_DE",
+    "uri": "http://schema4i.org/EnumGDVModificationCode_DE",
+    "description": "Zweistelliger Identifikationscode eines Geschäftsvorfalls gemäß GDV-Norm mit dem Veröffentlichungsdatum 2013. Er dient z.B. zur Schlüsselung eines Änderungsgrundes eines Versicherungsvertrages (Order#ModificationCode).",
+    "links": [{
+            "url": "http://schema4i.org/EnumGDVModificationCode",
+            "description": "Englische Dokumentation der Schlüsselwerte"
+        },
+        {
+            "url": "https://www.gdv-online.de/vuvm/bestand/rel2013/anl6.htm",
+            "description": "GDV Änderungsgrunde"
+        }
+    ],
+    "parents": [
+        { "@id": "http://schema4i.org/Order#ModificationCode" }
+    ],
+    "base": [
+        { "@id": "http://schema4i.org/Enumeration" }
+    ],
+    "multipletypes": {},
+    "context": {
+        "@context": {
+            "@version": 1.1,
+            "s4i": "http://schema4i.org/",
+            "Bei Erstausstattung (Stichtagsbestand, Bestandsübernahme)": "s4i:EnumTransactionCode#00",
+            "Erstlieferung eines Vertrages neue Vertragsnummer nach Vertragstrennung / Nachversicherung z. B.: Umstellung Einzelversicherung in Gruppenversicherung / Umstellung Gruppenversicherung in Einzelversicherung": "s4i:EnumTransactionCode#01",
+            "VN-Wechsel": "s4i:EnumTransactionCode#02",
+            "Fahrzeugwechsel": "s4i:EnumTransactionCode#03",
+            "Änderung Regionalklasse / Tarifgruppe / Typklasse (KFZ)": "s4i:EnumTransactionCode#04",
+            "Änderung Deckungsumfang / Versicherungsschutz / Übergang von Vollversicherung auf Anwartschaft bzw. von Anwartschaft auf Vollversicherung": "s4i:EnumTransactionCode#05",
+            "Änderung der SFR-Einstufung (KFZ) / Beitragsrückerstattung (KV)": "s4i:EnumTransactionCode#06",
+            "Kurzfristiger Einschluß oder Änderung der Deckung": "s4i:EnumTransactionCode#07",
+            "Wiederinkraftsetzung": "s4i:EnumTransactionCode#08",
+            "Änderung der Versicherungsdauer / des Versicherungsbeginnes": "s4i:EnumTransactionCode#09",
+            "Änderung zum Risiko / Risikozuschlag / Leistungsausschluß": "s4i:EnumTransactionCode#10",
+            "Änderung der Bedingungen": "s4i:EnumTransactionCode#11",
+            "Bedingungsgemäße Zuwachserhöhung / dynamische Leistungsanpassung": "s4i:EnumTransactionCode#12",
+            "Änderung der Zahlungsweise / Fälligkeit": "s4i:EnumTransactionCode#13",
+            "Änderung der Versicherungssumme": "s4i:EnumTransactionCode#14",
+            "Erhöhung Zusatzversicherung": "s4i:EnumTransactionCode#15",
+            "Einschluß Zusatz": "s4i:EnumTransactionCode#16",
+            "Ausschluß Zusatz": "s4i:EnumTransactionCode#17",
+            "Änderung der Beiträge (z. B. Beitragsanpassung, bedingungsgemäße Beitragserhöhung)": "s4i:EnumTransactionCode#18",
+            "Änderung Personendaten": "s4i:EnumTransactionCode#19",
+            "Vertragszusammenlegung": "s4i:EnumTransactionCode#20",
+            "Ersatzvertrag": "s4i:EnumTransactionCode#21",
+            "Bestandsübertragung (Übertragung von anderem Vermittler)": "s4i:EnumTransactionCode#22",
+            "Agenturnummernwechsel (Änderung der Organisationseinheit intern beim Vermittler)": "s4i:EnumTransactionCode#23",
+            "Neuzugang nach Vertragsneuordnung": "s4i:EnumTransactionCode#24",
+            "Neuzugang nach Tarifwechsel": "s4i:EnumTransactionCode#25",
+            "Ablehnung der Dynamikerhöhung": "s4i:EnumTransactionCode#26",
+            "Bedingungsgemäße Zuwachserhöhung / nichtdynamische Leistungsanpassung (z. B. bei Aufbaumodellen)": "s4i:EnumTransactionCode#27",
+            "Umstellung der Todesfalleistung in Prozent": "s4i:EnumTransactionCode#28",
+            "Wegfall des Risikovorlaufs": "s4i:EnumTransactionCode#29",
+            "Tarifliche Beitragsumstellung (z. B. Tarif mit ermäßigtem Anfangsbeitrag)": "s4i:EnumTransactionCode#30",
+            "Tarifwechsel (Versicherungsscheinnummer bleibt bestehen)": "s4i:EnumTransactionCode#31",
+            "Zuzahlung": "s4i:EnumTransactionCode#32",
+            "Änderung des Bezugsrechts": "s4i:EnumTransactionCode#33",
+            "Folgerechnung": "s4i:EnumTransactionCode#34",
+            "Hauptfälligkeitsrechnung": "s4i:EnumTransactionCode#35",
+            "Neuzugang wegen Übernahme von anderem VU": "s4i:EnumTransactionCode#36",
+            "Übergang auf anderes VU": "s4i:EnumTransactionCode#37",
+            "SFR-Änderung abhängige Fahrzeuge Wechselkennzeichen (W-AKZ)": "s4i:EnumTransactionCode#38",
+            "sonstige Änderung": "s4i:EnumTransactionCode#99"
+        }
+    }
+}

--- a/src/Order.src.json
+++ b/src/Order.src.json
@@ -32,6 +32,10 @@
         "PaymentMethod": [
             { "@id": "http://schema.org/PaymentMethod" },
             { "@id": "http://schema4i.org/EnumPaymentMethodCode" }
+        ],
+        "ModificationCode": [
+            { "@id": "http://schema4i.org/EnumTransactionCode" },
+            { "@id": "http://schema4i.org/EnumGDVModificationCode" }
         ]
     },
     "context": {
@@ -99,11 +103,7 @@
                 "@type": "schema:Boolean"
             }, 
             "ModificationCode": {
-                "@id": "s4i:OrderModificationCode",
-                "@type": "@vocab",
-                "@context": {
-                    "@vocab": "s4i:EnumTransactionCode#"
-                }
+                "@id": "s4i:ModificationCode"
             },
             "OrderDate": {
                 "@id": "schema:orderDate",

--- a/src/OrderModificationCode.src.json
+++ b/src/OrderModificationCode.src.json
@@ -15,17 +15,18 @@
     "base": [
         { "@id": "http://schema4i.org/Property" }
     ],
-    "multipletypes": {},
+    "multipletypes": {
+        "ModificationCode": [
+            { "@id": "http://schema4i.org/EnumTransactionCode" },
+            { "@id": "http://schema4i.org/EnumGDVModificationCode" }
+        ]
+    },
     "context": {
         "@context": {
             "@version": 1.1,
             "s4i": "http://schema4i.org/",
             "ModificationCode": {
-                "@id": "s4i:OrderModificationCode",
-                "@type": "@vocab",
-                "@context": {
-                    "@vocab": "s4i:EnumTransactionCode#"
-                }
+                "@id": "s4i:ModificationCode"
             }
         }
     },
@@ -33,7 +34,17 @@
         "title": "Contract modification code is 'Address removed'",
         "tab": "tab-expanded",
         "input": {
-            "@context": {},
+            "@context": [
+                {
+                    "ModificationCode": {
+                        "@id": "http://schema4i.org/OrderModificationCode",
+                        "@type": "@vocab",
+                        "@context": {
+                            "@vocab": "http://schema4i.org/EnumTransactionCode#"
+                        }
+                    }
+                }
+            ],
             "ModificationCode": "110011003"
         },
         "context": {}


### PR DESCRIPTION
This commits changes ModificationCode in Order from an OrderModificationCode to a mutlipleType of EnumTransactionCode and EnumGDVModificationCode. OrderModificationCode is no longer being used in the Order object.
OrderModificationCode is also now a multipleType of EnumTransactionCode and EnumGDVModificationCode instead of just EnumTransactionCode