### PR TITLE
Add InboundDelivery to BTA

### DIFF
--- a/src/BusinessTransactionDelivery.src.json
+++ b/src/BusinessTransactionDelivery.src.json
@@ -4,7 +4,7 @@
     "description": "Information about the delivery of business transactions. This is a package of data that bundles various business transactions and is provided by a provider. The object BusinessTransactionDelivery contains information about the transport of business transaction data. The provider is typically an insurance company or pool, etc.",
     "links": [],
     "parents": [
-        { "@id": "http://schema4i.org/BusinessTransferAction#Delivery" }
+        { "@id": "http://schema4i.org/BusinessTransferAction#InboundDelivery" }
     ],
     "base": [
         { "@id": "http://schema4i.org/ParcelDelivery" }

--- a/src/BusinessTransferAction.src.json
+++ b/src/BusinessTransferAction.src.json
@@ -1,7 +1,7 @@
 {
     "type": "BusinessTransferAction",
     "uri": "http://schema4i.org/BusinessTransferAction",
-    "description": "An Action to transfer some form of business transaction. It is usually triggered by a party involved in an insurance contract and represents an action that affects the insurance contract itself or third parties involved. This can e.g. deal with information about a claim, termination or change to the contract.",
+    "description": "An Action to transfer some form of business transaction. It is usually triggered by a party involved in an insurance contract and represents an action that affects the insurance contract itself or third parties involved. This can e.g. deal with information about a claim, termination or change to the contract.\n\n The 'Delivery' property has been superseded by the 'InboundDelivery' property.",
     "links": [],
     "parents": [
         { "@id": "http://schema4i.org/MoneyTransferAction" }
@@ -37,6 +37,10 @@
                 "@type": "schema:DateTime"
             },
             "Delivery": {
+                "@id": "s4i:BusinessTransactionDelivery",
+                "@type": "s4i:BusinessTransactionDelivery"
+            },
+            "InboundDelivery": {
                 "@id": "s4i:BusinessTransactionDelivery",
                 "@type": "s4i:BusinessTransactionDelivery"
             },
@@ -145,7 +149,7 @@
             "Category": "030",
             "Name": "Markus Heussen, Lindenstr. 48-52, 40233 Düsseldorf",
             "Description": "Policierung / Dokument erstellt",
-            "Delivery": {
+            "InboundDelivery": {
                 "@type": "BusinessTransactionDelivery",
                 "HasDeliveryMethod": "http://purl.org/goodrelations/v1#DeliveryModeDirectDownload",
                 "Provider": {


### PR DESCRIPTION
This commits adds InboundDelivery to BTA. It also add the following message in the Description of BTA: "The 'Delivery' property has been superseded by the 'InboundDelivery' property" 