### PR TITLE
added InsuranceClaim to supported types for DamageEvent.CauseOf

### DIFF
--- a/src/DamageEvent.src.json
+++ b/src/DamageEvent.src.json
@@ -9,7 +9,12 @@
     "base": [
         { "@id": "http://schema4i.org/Event" }
     ],
-    "multipletypes": {},
+    "multipletypes": {
+        "CauseOf": [
+            { "@id": "http://schema4i.org/Damage" },
+            { "@id": "http://schema4i.org/InsuranceClaim" }
+        ]
+    },
     "context": {
         "@context": {
             "@version": 1.1,
@@ -17,8 +22,7 @@
             "schema": "http://schema.org/",
             "DamageEvent": "s4i:DamageEvent",
             "CauseOf": {
-                "@id": "s4i:CauseOf",
-                "@type": "s4i:Damage"
+                "@id": "s4i:CauseOf"
             }
         }
     },

--- a/src/InsuranceClaim.src.json
+++ b/src/InsuranceClaim.src.json
@@ -5,7 +5,8 @@
     "links": [],
     "parents": [
         { "@id": "http://schema4i.org/Action#Object" },
-        { "@id": "http://schema4i.org/Action#Result" }
+        { "@id": "http://schema4i.org/Action#Result" },
+        { "@id": "http://schema4i.org/DamageEvent#CauseOf" }
     ],
     "base": [
         { "@id": "http://schema4i.org/CreativeWork" }

--- a/src/LossEvent.src.json
+++ b/src/LossEvent.src.json
@@ -26,6 +26,10 @@
                 "http://schema4i.org/LossEvent.jsonld",
                 "http://schema4i.org/City.jsonld",
                 "http://schema4i.org/Damage.jsonld",
+                "http://schema4i.org/InsuranceClaim.jsonld",
+                "http://schema4i.org/ID.jsonld",
+                "http://schema4i.org/ClaimSettlement.jsonld",
+                "http://schema4i.org/MonetaryAmount.jsonld",
                 "http://schema4i.org/Thing.jsonld"
             ],
             "@type": "LossEvent",
@@ -51,6 +55,21 @@
                     "@type": "MonetaryAmount",
                     "Currency": "EUR",
                     "Value": 20000
+                }
+            }, {
+                "@type": "InsuranceClaim",
+                "Name": "Insurance claim for liability damage",
+                "ClaimID": {
+                    "@type": "ID",
+                    "Value": "PD8734675"
+                },
+                "CauseOf": {
+                    "@type": "ClaimSettlement",
+                    "Amount": {
+                        "@type": "MonetaryAmount",
+                        "Currency": "EUR",
+                        "Value": 10000
+                    }
                 }
             }]
         },


### PR DESCRIPTION
The is the reciprocal relationship to InsuranceClaim.CausedBy and allows the structure to be constructed from either direction.