### PR TITLE
Improve tree-shakeability of typescript utils for bundlers

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,9 +20,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [24]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -86,19 +86,20 @@ async function generateTypes(language, outputDir, options) {
             exampleOutput = languageProcessor.writeExamples(schema, langConfig);
         }
 
-        let otherOutput = '';
-        if (typeof languageProcessor.writeOther === 'function') {
-            otherOutput = languageProcessor.writeOther(schema, langConfig);
+        /** @type Record<string, string> */
+        let otherOutput = {};
+        if (typeof languageProcessor.writeOthers === 'function') {
+            otherOutput = languageProcessor.writeOthers(schema, langConfig);
         }
 
         const typeOutputFile = path.resolve(outputDir, languageProcessor.getFileName(schema, 'types'));
         consoleLike.log(`Writing type definitions to ${typeOutputFile}`);
         await fs.writeFile(typeOutputFile, typeOutput, { encoding: 'utf-8' });
 
-        if (otherOutput) {
-            const otherOutputFile = path.resolve(outputDir, languageProcessor.getFileName(schema, 'util'));
+        for (const [fileType, content] of Object.entries(otherOutput)) {
+            const otherOutputFile = path.resolve(outputDir, languageProcessor.getFileName(schema, fileType));
             consoleLike.log(`Writing additional code to ${otherOutputFile}`);
-            await fs.writeFile(otherOutputFile, otherOutput, { encoding: 'utf-8' });    
+            await fs.writeFile(otherOutputFile, content, { encoding: 'utf-8' });    
         }
 
         if (exampleOutput) {

--- a/typegen/lang/typescript.js
+++ b/typegen/lang/typescript.js
@@ -18,6 +18,8 @@ const SKIP_TYPEOF_CHECKER = [
 const EXTENSIONS = {
     types: '.d.ts',
     util: '-util.ts',
+    guards: '-guards.ts',
+    enums: '-enums.ts',
     examples: '-examples.ts',
 }
 
@@ -77,7 +79,7 @@ function escape(identifier) {
 }
 
 const LANGUAGE = {
-        getFileName: (/** @type {Schema}*/ schema, /** @type {'types'|'util'|'examples'} */ purpose) => {
+        getFileName: (/** @type {Schema}*/ schema, /** @type {'types'|'util'|'guards'|'enums'|'examples'} */ purpose) => {
             return `${getFilenameComponent(schema)}${EXTENSIONS[purpose]}`;
         },
         writeTypes: ( /** @type {Schema}*/ schema, /** @type {boolean}*/ strict, /** @type {LangConfig} */ langConfig) => {
@@ -139,18 +141,14 @@ export type TypeByName<T extends string> = ${
 
         return output;
     },
-    writeOther: (/** @type {Schema}*/ schema, /** @type {LangConfig} */ langConfig) => {
+    writeOthers: (/** @type {Schema}*/ schema, /** @type {LangConfig} */ langConfig) => {
         const typeDefinitions = schema.types;
         const enumDefinitions = typeDefinitions.filter(td => td.enumValues);
         const complexTypeDefinitions = typeDefinitions.filter(td => !td.simpleType);
-        let output = `
+        const ancestorsList = {};
+        const descendantsList = {};
+        let guards = `
 import * as s4i from './${getFilenameComponent(schema)}${langConfig.esm ? '.js' : ''}';
-
-const ENUMS = new Map<string, Map<string, string>>();
-
-const ANCESTORS = new Map<string, string[]>();
-
-const DESCENDANTS = new Map<string, string[]>();
 
 function isType(obj: any, type: string) {
 return typeof obj === 'object' && obj !== null && (Array.isArray(obj["@type"]) ? obj["@type"].indexOf(type) > -1 : obj["@type"] === type);
@@ -164,7 +162,7 @@ return typeof obj === 'object' && obj !== null && (Array.isArray(obj["@type"]) ?
             const descendants = typeDefinition.listDescendants(typeDefinitions);
 
             if (!SKIP_TYPEOF_CHECKER.some(t => t.test(typeDefinition.type))) {
-                output += `
+                guards += `
 /**
 * Checks if the given object is an instance of ${typeDefinition.type}.
 */
@@ -176,70 +174,78 @@ return isType(obj, '${typeDefinition.type}')${ childTypes.length > 0 ? ' || ' + 
             }
 
             if (ancestors.length > 0) {
-
-                output += `
-ANCESTORS.set('${typeDefinition.type}', ['${ joinWithLineBreaks(ancestors.map(a => a.type), `', '`, `',\n    '`) }']);
-`;
-
+                ancestorsList[typeDefinition.type] = ancestors.map(a => a.type);
             }
             if (descendants.length > 0) {
-
-                output += `
-DESCENDANTS.set('${typeDefinition.type}', ['${ joinWithLineBreaks(descendants.map(a => a.type), `', '`, `',\n    '`) }']);
-`;
-
+                descendantsList[typeDefinition.type] = descendants.map(a => a.type);
             }
         }
-        output += `
+        guards += `
+const ANCESTORS = {
+${Object.entries(ancestorsList).map(([type, ancestors]) => `'${type}': ['${joinWithLineBreaks(ancestors, `', '`, `',\n'`)}']`).join(',\n')}
+} as const;
 
+export function getAncestors(type: string): string[] {
+    return ANCESTORS[type]?.slice() ?? [];
+}
+
+const DESCENDANTS = {
+${Object.entries(descendantsList).map(([type, descendants]) => `'${type}': ['${joinWithLineBreaks(descendants, `', '`, `',\n'`)}']`).join(',\n')}
+} as const;
+
+export function getDescendants(type: string): string[] {
+    return DESCENDANTS[type]?.slice() ?? [];
+}
 `;
-        let enumCount = 0;
+        const enumsList = {};
         for (const enumDefinition of enumDefinitions) {
-            const count = enumCount++;
-            output += `
-const E${count} = new Map();
-ENUMS.set('${enumDefinition.type}', E${count});
-${Object.entries(enumDefinition.enumValues).map(([key, value]) => `E${count}.set('${key}', '${value.replace(/'/g, `\\'`)}');`).join('\n')}
-`;
+            enumsList[enumDefinition.type] = enumDefinition.enumValues;
         }
         const enumTypes = enumDefinitions.filter(td => !I18N_SUFFIXES.some(suffix => td.type.endsWith(suffix))).map(td => escape(td.type));
         const joinedEnumTypes = joinWithLineBreaks(enumTypes, `'|'`, `'|\n    '`);
-        output += `
+        const enums = `
 export type EnumTypes = '${joinedEnumTypes}';
 
+const ENUMS = {
+${Object.entries(enumsList).map(([type, values]) => {
+        const enumName = escape(type);
+        const enumEntries = Object.entries(values).map(([key, value]) => `'${key}': '${value.replace(/'/g, `\\'`)}'`).join(',\n');
+        return `'${enumName}': {
+${enumEntries}
+}`;
+    }).join(',\n')}
+} as const;
+
 export function mapEnum(type: EnumTypes, value: string, lang: '${I18N_SUFFIXES.join(`'|'`)}' = '${DEFAULT_I18N_SUFFIX}'): string {
-const enumName = lang !== '${DEFAULT_I18N_SUFFIX}' ? type + '_' + lang : type;
-return ENUMS.get(enumName)?.get(value);
+    const enumName = lang !== '${DEFAULT_I18N_SUFFIX}' ? type + '_' + lang : type;
+    return ENUMS[enumName]?.[value];
 }
 
 export function listEnumKeys(type: EnumTypes, lang: '${I18N_SUFFIXES.join(`'|'`)}' = '${DEFAULT_I18N_SUFFIX}'): string[] {
-const enumName = lang !== '${DEFAULT_I18N_SUFFIX}' ? type + '_' + lang : type;
-const enumDef = ENUMS.get(enumName);
-return enumDef ? [...enumDef.keys()] : undefined;
+    const enumName = lang !== '${DEFAULT_I18N_SUFFIX}' ? type + '_' + lang : type;
+    const enumDef = ENUMS[enumName];
+    return enumDef ? Object.keys(enumDef) : undefined;
 }
 
 export function listEnumValues(type: EnumTypes, lang: '${I18N_SUFFIXES.join(`'|'`)}' = '${DEFAULT_I18N_SUFFIX}'): string[] {
-const enumName = lang !== '${DEFAULT_I18N_SUFFIX}' ? type + '_' + lang : type;
-const enumDef = ENUMS.get(enumName);
-return enumDef ? [...enumDef.values()] : undefined;
-}
-
-export function getAncestors(type: string): string[] {
-return ANCESTORS.get(type)?.slice() ?? [];
-}
-
-export function getDescendants(type: string): string[] {
-return DESCENDANTS.get(type)?.slice() ?? [];
-}
-
-export function listEnum(type: EnumTypes, lang: '${I18N_SUFFIXES.join(`'|'`)}' = '${DEFAULT_I18N_SUFFIX}'): Record<string, any> {
     const enumName = lang !== '${DEFAULT_I18N_SUFFIX}' ? type + '_' + lang : type;
-    const enumDef = ENUMS.get(enumName);
-    return enumDef ? Object.fromEntries(enumDef) : undefined;
+    const enumDef = ENUMS[enumName];
+    return enumDef ? Object.values(enumDef) : undefined;
+}
+
+export function listEnum(type: EnumTypes, lang: '${I18N_SUFFIXES.join(`'|'`)}' = '${DEFAULT_I18N_SUFFIX}'): Readonly<Record<string, any>> {
+    const enumName = lang !== '${DEFAULT_I18N_SUFFIX}' ? type + '_' + lang : type;
+    const enumDef = ENUMS[enumName];
+    return enumDef;
 }
 
 `;
-        return output;
+
+    const util = `export * from './${getFilenameComponent(schema)}${EXTENSIONS['guards'].replace('.ts', '')}';
+export * from './${getFilenameComponent(schema)}${EXTENSIONS['enums'].replace('.ts', '')}';
+`;
+
+        return {guards, enums, util};
     },
     writeExamples: (/** @type {Schema}*/ schema, /** @type {LangConfig} */ langConfig) => {
         const typeDefinitions = schema.types;


### PR DESCRIPTION
Until now, the generated typescript utility code was not properly tree-shakeable because the module included top level function invocations that bundlers could not reliably optimize away since they might contain side effects.

This merge refactors the generated code to use plain JS objects instead of maps, so the `map.set(...)` invocations are no longer neccessary. It also splits the *-util module into *-guards and *-enums (while maintaining *-util for exports). This allows bundlers who only import the `is<Type>(...)` functions to optimize everything else away.

Note that this is still not a perfect solution - any code that uses `mapEnum` or other related enum functions still has to import the entire enum bundle. Making enums tree-shakeable would require exporting every enum list individually and importing only the specific types being used instead of relying on a catch-all function like `mapEnum`. This would also only work if the enum types are known at compile time. Since this is a very niche optimization that would also require code changes on the consumer side to be utilized it has not been implemented for now.